### PR TITLE
use correct mime-type shortcut

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -416,7 +416,7 @@ DuoTest.prototype.run = function*(){
 
 DuoTest.prototype.send = function(){
   return function*(){
-    this.type = 'javascript';
+    this.type = 'js';
     this.body = assets.duotest;
     debug('sent duotest()');
   };


### PR DESCRIPTION
the `mime-types` module has no shortcut named 'javascript' so duotest.js was being received as `application/octet-stream` rather than `application/javascript`
