### PR TITLE
spawn command with gnode like with duo

### DIFF
--- a/bin/_duo-test
+++ b/bin/_duo-test
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+var reporters = require('mocha').reporters;
+var Command = require('commander').Command;
+var pascal = require('to-pascal-case');
+var exists = require('fs').existsSync;
+var base = require('path').basename;
+var fmt = require('util').format;
+var pkg = require('../package');
+var join = require('path').join;
+var assert = require('assert');
+var DuoTest = require('..');
+var cwd = process.cwd();
+var co = require('co');
+var env = process.env;
+
+/**
+ * Default browser
+ */
+
+var browser = env.BROWSER || 'chrome';
+
+/**
+ * Program
+ */
+
+var program = new Command('duo-test')
+  .usage('<command> [options]')
+  .option('-p, --pathname <path>', 'tests path, defaults to /test', '/test')
+  .option('-c, --commands <list>', 'shell commands to run on refresh', list, [])
+  .option('-m, --middleware <file>', 'a file that exposes a function that accepts koa app')
+  .option('-t, --title <title>', 'set a title to your tests [' + base(cwd) + ']', base(cwd))
+  .option('-B, --build <path>', 'set the built file path when using the default.html [/build.js]', '/build.js')
+  .option('-R, --reporter <name>', 'mocha reporter [dot]', 'dot')
+  .version(pkg.version);
+
+/**
+ * Saucelabs
+ */
+
+program
+  .command('saucelabs')
+  .description('run tests using saucelabs')
+  .option('-b, --browsers <browsers>', 'browser(s) you want to test on [$BROWSER]', list, [browser])
+  .option('-u, --user <user>', 'saucelabs user [$SAUCE_USER]', env.SAUCE_USER)
+  .option('-k, --key <key>', 'saucelabs key [$SAUCE_KEY]', env.SAUCE_KEY)
+  .action(lazy('./saucelabs'));
+
+/**
+ * Browser
+ */
+
+program
+  .command('browser [name]')
+  .description('run tests using a browser')
+  .action(lazy('./browser'));
+
+/**
+ * PhantomJS
+ */
+
+program
+  .command('phantomjs')
+  .description('run tests using phantomjs')
+  .action(lazy('./phantom.js'));
+
+/**
+ * Parse
+ */
+
+program.parse(process.argv);
+
+/**
+ * Middleware
+ */
+
+if (program.middleware) {
+  var path = join(cwd, program.middleware);
+  if (!exists(path)) error('cannot find middleware %s', path);
+  var middleware = require(path);
+}
+
+/**
+ * Lazy load `path` and pass `args`.
+ */
+
+function lazy(path){
+  return co(function*(){
+    var args = [].slice.call(arguments);
+    var command = args.pop();
+
+    try {
+      var cmd = require(path);
+      yield cmd(command, duotest(), args);
+    } catch (e) {
+      error(e.stack);
+    }
+  });
+}
+
+/**
+ * Create basic DuoTest instance.
+ */
+
+function duotest(){
+  var cmds = program.commands.filter(string);
+  var mw = middleware || function(){};
+  var dt = DuoTest(cwd);
+
+  // reporter
+  var reporter = pascal(program.reporter);
+  dt.Reporter = reporters[reporter];
+  assert(dt.Reporter, 'reporter "' + reporter + '" was not found');
+
+  // add commands
+  cmds.forEach(dt.command.bind(dt));
+
+  // set build
+  dt.build(program.build);
+
+  // middleware
+  mw(dt.app);
+
+  // set pathname
+  dt.pathname(program.pathname);
+
+  // SIGINT
+  process.on('SIGINT', function(){
+    dt.destroy();
+    setImmediate(function(){
+      process.exit(0);
+    });
+  });
+
+  return dt;
+}
+
+/**
+ * is string.
+ */
+
+function string(val){
+  return 'string' == typeof val;
+}
+
+/**
+ * Error
+ */
+
+function error(){
+  var msg = fmt.apply(null, arguments);
+  console.error();
+  console.error('  %s', msg);
+  console.error();
+  process.exit(1);
+}
+
+/**
+ * List
+ */
+
+function list(val){
+  if ('"' == val[0]) val = val.slice(1, -1);
+  return val.split(/ *, */);
+}

--- a/bin/duo-test
+++ b/bin/duo-test
@@ -1,165 +1,30 @@
-#!/usr/bin/env node --harmony-generators
-
-var reporters = require('mocha').reporters;
-var pascal = require('to-pascal-case');
-var exists = require('fs').existsSync;
-var base = require('path').basename;
-var program = require('commander');
-var fmt = require('util').format;
-var pkg = require('../package');
-var join = require('path').join;
-var assert = require('assert');
-var DuoTest = require('..');
-var cwd = process.cwd();
-var co = require('co');
-var env = process.env;
+#!/usr/bin/env node
 
 /**
- * Default browser
+ * Module dependencies.
  */
 
-var browser = env.BROWSER || 'chrome';
+var path = require('path');
+var spawn = require('win-fork');
 
 /**
- * Program
+ * Resolve
  */
 
-program
-  .usage('<command> [options]')
-  .option('-p, --pathname <path>', 'tests path, defaults to /test', '/test')
-  .option('-c, --commands <list>', 'shell commands to run on refresh', list, [])
-  .option('-m, --middleware <file>', 'a file that exposes a function that accepts koa app')
-  .option('-t, --title <title>', 'set a title to your tests [' + base(cwd) + ']', base(cwd))
-  .option('-B, --build <path>', 'set the built file path when using the default.html [/build.js]', '/build.js')
-  .option('-R, --reporter <name>', 'mocha reporter [dot]', 'dot')
-  .version(pkg.version);
+var gnode = require.resolve('gnode/bin/gnode');
+var duo = path.resolve(__dirname, '_duo-test');
+var args = [duo].concat(process.argv.slice(2));
 
 /**
- * Saucelabs
+ * Spawn
  */
 
-program
-  .command('saucelabs')
-  .description('run tests using saucelabs')
-  .option('-b, --browsers <browsers>', 'browser(s) you want to test on [$BROWSER]', list, [browser])
-  .option('-u, --user <user>', 'saucelabs user [$SAUCE_USER]', env.SAUCE_USER)
-  .option('-k, --key <key>', 'saucelabs key [$SAUCE_KEY]', env.SAUCE_KEY)
-  .action(lazy('./saucelabs'));
+var proc = spawn(gnode, args, { stdio: 'inherit' });
 
 /**
- * Browser
+ * Exit
  */
 
-program
-  .command('browser [name]')
-  .description('run tests using a browser')
-  .action(lazy('./browser'));
-
-/**
- * PhantomJS
- */
-
-program
-  .command('phantomjs')
-  .description('run tests using phantomjs')
-  .action(lazy('./phantom.js'));
-
-/**
- * Parse
- */
-
-program.parse(process.argv);
-
-/**
- * Middleware
- */
-
-if (program.middleware) {
-  var path = join(cwd, program.middleware);
-  if (!exists(path)) error('cannot find middleware %s', path);
-  var middleware = require(path);
-}
-
-/**
- * Lazy load `path` and pass `args`.
- */
-
-function lazy(path){
-  return co(function*(){
-    var args = [].slice.call(arguments);
-    var command = args.pop();
-
-    try {
-      var cmd = require(path);
-      yield cmd(command, duotest(), args);
-    } catch (e) {
-      error(e.stack);
-    }
-  });
-}
-
-/**
- * Create basic DuoTest instance.
- */
-
-function duotest(){
-  var cmds = program.commands.filter(string);
-  var mw = middleware || function(){};
-  var dt = DuoTest(cwd);
-
-  // reporter
-  var reporter = pascal(program.reporter);
-  dt.Reporter = reporters[reporter];
-  assert(dt.Reporter, 'reporter "' + reporter + '" was not found');
-
-  // add commands
-  cmds.forEach(dt.command.bind(dt));
-
-  // set build
-  dt.build(program.build);
-
-  // middleware
-  mw(dt.app);
-
-  // set pathname
-  dt.pathname(program.pathname);
-
-  // SIGINT
-  process.on('SIGINT', function(){
-    dt.destroy();
-    setImmediate(function(){
-      process.exit(0);
-    });
-  });
-
-  return dt;
-}
-
-/**
- * is string.
- */
-
-function string(val){
-  return 'string' == typeof val;
-}
-
-/**
- * Error
- */
-
-function error(){
-  var msg = fmt.apply(null, arguments);
-  console.error();
-  console.error('  %s', msg);
-  console.error();
-  process.exit(1);
-}
-
-/**
- * List
- */
-
-function list(val){
-  if ('"' == val[0]) val = val.slice(1, -1);
-  return val.split(/ *, */);
-}
+proc.on('exit', function(code){
+  process.exit(code);
+});

--- a/package.json
+++ b/package.json
@@ -9,17 +9,19 @@
     "co-timeout": "0.0.1",
     "commander": "^2.2.0",
     "debug": "^1.0.2",
+    "gnode": "0.0.8",
     "koa": "^0.8.1",
     "koa-route": "^1.1.4",
     "koa-static": "^1.4.6",
     "localtunnel": "^1.3.0",
+    "mocha": "^1.21.4",
     "open": "0.0.5",
     "queue-component": "git://github.com/component/queue.git#1.0.6",
     "thunkify": "^2.1.2",
     "to-pascal-case": "0.0.2",
     "wd": "^0.3.3",
-    "mocha": "^1.21.4",
-    "wd-browser": "1.0.1"
+    "wd-browser": "1.0.1",
+    "win-fork": "^1.1.1"
   },
   "bin": {
     "duo-test": "./bin/duo-test"


### PR DESCRIPTION
so it actually works on linux and windows.

``` bash
#!/usr/bin/env node --harmony-generators
```

works only with Mac OSX. On Linux you can't pass flags to an environment  (see http://stackoverflow.com/a/20980886).

So I've basically changed it to how `duo` does it.
