### PR TITLE
package.json: Update gnode to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "co-timeout": "0.0.1",
     "commander": "^2.2.0",
     "debug": "^1.0.2",
-    "gnode": "0.0.8",
+    "gnode": "^0.1.0",
     "koa": "^0.8.1",
     "koa-route": "^1.1.4",
     "koa-static": "^1.4.6",


### PR DESCRIPTION
this patch allows duo-test(1) to run on node 0.10.  currently, when
invoking duo-test, you just get a `"SyntaxError: Unexpected
identifier"` exception and a crash.

gnode's downstream dependency "regenerator" changed its API
drastically, which broke gnode.  the latest version compensates for the
API change, and pins a working version of regenerator.
