### PR TITLE
use common saucelabs env variable names

### DIFF
--- a/bin/_duo-test
+++ b/bin/_duo-test
@@ -42,8 +42,8 @@ program
   .command('saucelabs')
   .description('run tests using saucelabs')
   .option('-b, --browsers <browsers>', 'browser(s) you want to test on [$BROWSER]', list, [browser])
-  .option('-u, --user <user>', 'saucelabs user [$SAUCE_USERNAME]', env.SAUCE_USERNAME)
-  .option('-k, --key <key>', 'saucelabs key [$SAUCE_ACCESS_KEY]', env.SAUCE_ACCESS_KEY)
+  .option('-u, --user <user>', 'saucelabs user [$SAUCE_USERNAME]', env.SAUCE_USER || env.SAUCE_USERNAME)
+  .option('-k, --key <key>', 'saucelabs key [$SAUCE_ACCESS_KEY]', env.SAUCE_KEY || env.SAUCE_ACCESS_KEY)
   .action(lazy('./saucelabs'));
 
 /**


### PR DESCRIPTION
In most of the docs on the Saucelabs site (https://docs.saucelabs.com/tutorials/js-unit-testing/) they reference the env vars as such:

SAUCE_USERNAME
SAUCE_ACCESS_KEY
