### PR TITLE
load middleware

### DIFF
--- a/bin/_duo-test
+++ b/bin/_duo-test
@@ -72,13 +72,14 @@ program
 program.parse(process.argv);
 
 /**
- * Middleware
+ * Load middleware.
  */
 
-if (program.middleware) {
+function middleware(){
+  if (!program.middleware) return function(){};
   var path = join(cwd, program.middleware);
   if (!exists(path)) error('cannot find middleware %s', path);
-  var middleware = require(path);
+  return require(path);
 }
 
 /**
@@ -105,7 +106,7 @@ function lazy(path){
 
 function duotest(){
   var cmds = program.commands.filter(string);
-  var mw = middleware || function(){};
+  var mw = middleware();
   var dt = DuoTest(cwd);
 
   // reporter


### PR DESCRIPTION
The `middleware` variable is getting initialized _after_ the `duotest()` function is getting evaluated because of this:
- `lazy()` is getting called above `program.middleware`
- `lazy()` calls `duotest()`, which calls `var mw = middleware || function(){}`, but `middleware` hasn't been defined yet.

This PR makes it so `middleware()` resolves correctly.
