### PR TITLE
Update example Makefiles with `--stdout` flag

### DIFF
--- a/examples/advanced/Makefile
+++ b/examples/advanced/Makefile
@@ -8,7 +8,7 @@
 T= ../../bin/duo-test -c make
 
 build.js: test/test.js
-	@duo $< > build.js
+	@duo --stdout $< > build.js
 
 test-browser:
 	@$(T) browser

--- a/examples/fatal-errors/Makefile
+++ b/examples/fatal-errors/Makefile
@@ -8,7 +8,7 @@
 T= ../../bin/duo-test -c make -R dot -P 3000
 
 build.js: test/test.js
-	@duo $< > build.js
+	@duo --stdout $< > build.js
 
 test-browser:
 	@$(T) browser

--- a/examples/library/Makefile
+++ b/examples/library/Makefile
@@ -4,7 +4,7 @@ TESTS = $(filter-out test/tests.js, $(wildcard test/*.js))
 SRC = $(wildcard index.js lib/*.js)
 
 build.js: test/tests.js
-	duo --root . --type js < $< > $@
+	duo --root . --type js --stdout < $< > $@
 
 test/tests.js: $(SRC) $(TESTS)
 	@echo '// GENERATED FILE: DO NOT EDIT!' > $@

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -8,7 +8,7 @@
 T= ../../bin/duo-test -c make -R dot -P 3000
 
 build.js: test/test.js
-	@duo $< > build.js
+	@duo --stdout $< > build.js
 
 test-browser:
 	@$(T) browser


### PR DESCRIPTION
Change was introduced in https://github.com/duojs/duo/commit/a796bfb80ee2c16ef2b4b4c63b4c7fcd50910c75; updates the examples to work again.