### PR TITLE
add saucelabs reporting and cli options

### DIFF
--- a/bin/_duo-test
+++ b/bin/_duo-test
@@ -45,6 +45,8 @@ program
   .option('-b, --browsers <browsers>', 'browser(s) you want to test on [$BROWSER]', list, [browser])
   .option('-u, --user <user>', 'saucelabs user [$SAUCE_USERNAME]', env.SAUCE_USER || env.SAUCE_USERNAME)
   .option('-k, --key <key>', 'saucelabs key [$SAUCE_ACCESS_KEY]', env.SAUCE_KEY || env.SAUCE_ACCESS_KEY)
+  .option('-n, --number <number>', 'saucelabs build number/version [$SAUCE_BUILD_NUMBER]', env.SAUCE_BUILD_NUMBER || null)
+  .option('-i, --public <level>', 'saucelabs visibility level [$SAUCE_VISIBILITY]', env.SAUCE_VISIBILITY || 'team')
   .action(lazy('./saucelabs'));
 
 /**


### PR DESCRIPTION
This PR lets users define some options to report to saucelabs that are required in order to get status badges.  Notably `public`, `build`, and `passed`.  I had a hard time figuring out what CLI shortcuts I should use so if `-n` and `-i` aren't appealing I can change those to whatever.