### PR TITLE
Adds jsonp callback prefix

### DIFF
--- a/client/duo-test.js
+++ b/client/duo-test.js
@@ -105,7 +105,7 @@ function event(name, path){
       var json = stringify({ event: name, data: obj });
       var data = encodeURIComponent(json);
       var query = '?id=' + id + '&data=' + data;
-      jsonp(path + query, next);
+      jsonp(path + query, { prefix: '__dtjp' }, next);
     });
   };
 };


### PR DESCRIPTION
- This will prevent callback collision when other libraries use the default prefix.
- I was seeing this while testing a library that also made use of the `webmodules/jsonp` lib. Events firing during the test were hijacking requests the library was making.
- The result is that events hang, making the debug process arduous.

I updated the library being tested, but felt it would be beneficial to add a prefix here as well, given the difficulty of the debug process