### PR TITLE
Improve error message when PhantomJS is not installed

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -10,6 +10,7 @@ var timeout = require('co-timeout');
 var thunkify = require('thunkify');
 var assert = require('assert');
 var wd = require('wd');
+var which = require('which').sync;
 
 /**
  * Expose `PhantomJS`
@@ -65,8 +66,15 @@ PhantomJS.prototype.connect = function(){
     var buf = '';
     var m;
 
+    var phantomPath;
+    try {
+      phantomPath = which('phantomjs');
+    } catch(err) {
+      throw new Error('Could not find PhantomJS. Please ensure PhantomJS is installed globally and is available in your $PATH.');
+    }
+
     // spawn
-    self.proc = spawn('phantomjs', ['--wd'].concat(self.args));
+    self.proc = spawn(phantomPath, ['--wd'].concat(self.args));
     self.proc.stdout.on('data', ondata);
     self.proc.on('error', done);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "to-pascal-case": "0.0.2",
     "wd": "^0.3.3",
     "wd-browser": "1.1.0",
+    "which": "^1.1.1",
     "win-fork": "^1.1.1"
   },
   "bin": {


### PR DESCRIPTION
Without this patch, we simply try to spawn `phantomjs` without first
checking if it's installed, which results in this rather cryptic
error message when PhantomJS isn't available in a user's `$PATH`:

```
  Error: spawn phantomjs ENOENT
    at exports._errnoException (util.js:749:11)
    at Process.ChildProcess._handle.onexit (child_process.js:987:32)
    at child_process.js:1079:20
    at process._tickCallback (node.js:340:13)
```

This patch checks to be sure the `phantomjs` binary is available in the
user's `$PATH` and throws a descriptive error if it's not.