### PR TITLE
Use local phantomjs dependency when available

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,9 @@ Options:
   -V, --version            output the version number
 ```
 
-Note that to use the PhantomJS runner, the `phantomjs` binary must be available in your `$PATH`. You install PhantomJS by running `npm install -g phantomjs` or download it from the [PhantomJS website](http://phantomjs.org).
+#### PhantomJS
+
+`duo-test` will first try to use your project's local PhantomJS dependency, and then fall back on a global PhantomJS installation. Make sure PhantomJS is installed either as a devDependency (`npm install --save-dev phantomjs`) or globally (`npm -g install phantomjs`, or follow the instructions on <http://phantomjs.org/>).
 
 ### License
 

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -65,12 +65,10 @@ PhantomJS.prototype.connect = function(){
   return function(done){
     var buf = '';
     var m;
+    var phantomPath = findPhantomBinary();
 
-    var phantomPath;
-    try {
-      phantomPath = which('phantomjs');
-    } catch(err) {
-      throw new Error('Could not find PhantomJS. Please ensure PhantomJS is installed globally and is available in your $PATH.');
+    if (phantomPath === null) {
+      throw new Error('Could not find PhantomJS. Please ensure PhantomJS is installed as a devDependency of your project (npm install --save-dev phantomjs), or is available in your $PATH.');
     }
 
     // spawn
@@ -155,4 +153,34 @@ PhantomJS.prototype.get = function*(url){
 
 PhantomJS.prototype.toString = function(){
   return 'phantomjs';
+};
+
+/**
+ * Find a PhantomJS binary by first looking for a local installation (npm
+ * package), then looking for a global PhantomJS installation.  If no PhantomJS
+ * installation is found, return `null`.
+ *
+ * @api private
+ * @return {string|null}
+ */
+
+function findPhantomBinary() {
+  var phantomjs = null;
+
+  // Try to find the user's local phantomjs module.
+  try {
+    phantomjs = require('phantomjs').path;
+  } catch(err) {
+    console.log(err);
+    // Do nothing
+  }
+
+  // Try to find the global phantomjs binary.
+  try {
+    phantomjs = which('phantomjs');
+  } catch(err) {
+    // Do nothing
+  }
+
+  return phantomjs;
 };


### PR DESCRIPTION
Extends #73, if you want to merge that one first I'll rebase to clean this up.

Allow use of a project's local PhantomJS dependency (generally installed via `npm install --save-dev phantomjs`), falling back on a global PhantomJS installation, finally degrading to a helpful error message if PhantomJS is not installed.

Not sure of the best way to test this short of some gross programmatic `npm` usage. Feel free to suggest something there and happy to whip up some tests.