### PR TITLE
Tests: Find an open port before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "devDependencies": {
     "co-mocha": "0.0.4",
     "co-request": "^0.2.0",
-    "minstache": "^1.2.0"
+    "minstache": "^1.2.0",
+    "portfinder": "^0.4.0"
   },
   "description": "Duo's testing utility.",
   "main": "index.js",

--- a/test/api.js
+++ b/test/api.js
@@ -3,6 +3,7 @@ var request = require('co-request');
 var parse = require('url').parse;
 var assert = require('assert');
 var DuoTest = require('..');
+var getOpenPort = require('./get-open-port');
 var env = process.env;
 
 describe('API', function(){
@@ -78,8 +79,9 @@ describe('API', function(){
 
   describe('.listen(port)', function(){
     it('should start listening on the given port', function*(){
+      var port = yield getOpenPort();
       dt.pathname('fixtures/advanced');
-      yield dt.listen(3000);
+      yield dt.listen(port);
       var res = yield request(dt.url());
       assert.equal(200, res.statusCode);
       assert.equal('advanced', res.body.match(/<title>([^<]+)<\/title>/)[1]);
@@ -87,9 +89,10 @@ describe('API', function(){
     });
 
     it('should serve /duotest.js', function*(){
+      var port = yield getOpenPort();
       dt.pathname('fixtures/advanced');
-      yield dt.listen(3000);
-      var res = yield request('http://localhost:3000/duotest.js');
+      yield dt.listen(port);
+      var res = yield request('http://localhost:' + port + '/duotest.js');
       assert.equal(200, res.statusCode);
       yield dt.destroy();
     });
@@ -97,9 +100,10 @@ describe('API', function(){
 
   describe('.expose()', function(){
     it('should expose the server on localtunnel', function*(){
+      var port = yield getOpenPort();
       this.timeout(4e3);
       dt.pathname('fixtures/advanced');
-      yield dt.listen(3000);
+      yield dt.listen(port);
       yield dt.expose();
       var parsed = parse(dt.url());
       assert.equal('localtunnel', parsed.host.split('.')[1]);

--- a/test/get-open-port.js
+++ b/test/get-open-port.js
@@ -1,0 +1,14 @@
+
+var getPort = require('portfinder').getPort;
+
+/**
+ * Yieldable version of portfinder.getPort.
+ */
+
+module.exports = function*(){
+  return yield new Promise(function(resolve, reject){
+    require('portfinder').getPort(function(err, port){
+      err ? reject(err) : resolve(port);
+    });
+  });
+};


### PR DESCRIPTION
If port 3000 is in use, the tests will throw an error. This patch
finds an open port and uses that in tests, eliminating these false test
failures.